### PR TITLE
fix error from API response being HTTP/1.0

### DIFF
--- a/answers/lesson05/lesson05.ino
+++ b/answers/lesson05/lesson05.ino
@@ -44,7 +44,7 @@ void doRequest(String location){
          // Check HTTP status
           char status[32] = {0};
           client.readBytesUntil('\r', status, sizeof(status));
-          if (strcmp(status, "HTTP/1.1 200 OK") != 0) {
+          if (strcmp(status, "HTTP/1.0 200 OK") != 0) {
             Serial.print(F("Unexpected response: "));
             Serial.println(status);
             return;

--- a/answers/lesson06/lesson06.ino
+++ b/answers/lesson06/lesson06.ino
@@ -116,7 +116,7 @@ void doRequest(String location){
          // Check HTTP status
           char status[32] = {0};
           client.readBytesUntil('\r', status, sizeof(status));
-          if (strcmp(status, "HTTP/1.1 200 OK") != 0) {
+          if (strcmp(status, "HTTP/1.0 200 OK") != 0) {
             Serial.print(F("Unexpected response: "));
             Serial.println(status);
             return;

--- a/exercises/lesson05/lesson05.ino
+++ b/exercises/lesson05/lesson05.ino
@@ -45,7 +45,7 @@ void doRequest(String location){
          // Sjekker om HTTP status vi fikk tilbake var 200OK eller ei.
           char status[32] = {0};
           client.readBytesUntil('\r', status, sizeof(status));
-          if (strcmp(status, "HTTP/1.1 200 OK") != 0) {
+          if (strcmp(status, "HTTP/1.0 200 OK") != 0) {
             Serial.print(F("Unexpected response: "));
             Serial.println(status);
             return;

--- a/exercises/lesson06/lesson06.ino
+++ b/exercises/lesson06/lesson06.ino
@@ -125,7 +125,7 @@ void doRequest(String location){
          // Check HTTP status
           char status[32] = {0};
           client.readBytesUntil('\r', status, sizeof(status));
-          if (strcmp(status, "HTTP/1.1 200 OK") != 0) {
+          if (strcmp(status, "HTTP/1.0 200 OK") != 0) {
             Serial.print(F("Unexpected response: "));
             Serial.println(status);
             return;


### PR DESCRIPTION
The YR API has started returning HTTP/1.0 responses when the request is HTTP/1.0.
This changes the code to expect a HTTP/1.0 response instead of HTTP/1.1 as the request is HTTP/1.0.